### PR TITLE
Fix restart_module function

### DIFF
--- a/LD2410/ld2410.py
+++ b/LD2410/ld2410.py
@@ -190,13 +190,13 @@ class LD2410():
         if reconnect:
             logging.info("Baud rate set command issued. Calling restart.")
             # Restart the driver with the new baudrate
-            self.restart_module(BAUD_LOOKUP[baud_rate])
+            self.restart_module(baud_rate)
 
     def factory_reset(self, reconnect=True):
         logging.warning("Module will now be factory reset")
         self.send_command(CMD_FACTORY_RESET)
         if reconnect:
-            self.restart_module(BAUD_LOOKUP[PARAM_DEFAULT_BAUD])
+            self.restart_module(PARAM_DEFAULT_BAUD)
 
     def restart_module(self, new_baud=None):
         logging.info("Restarting module")


### PR DESCRIPTION
A KeyError would be thrown whenever the `restart_module()` function is called. This PR fixes this behaviour by removing the BAUD_LOOKUP in the function `factory_reset()` and `set_baud_rate()`.

```
Traceback (most recent call last):
  File "/home/auke/Downloads/LD2410/example.py", line 69, in <module>
    main()
  File "/home/auke/Downloads/LD2410/example.py", line 13, in main
    radar.factory_reset()
  File "/home/auke/Downloads/LD2410/LD2410/ld2410.py", line 199, in factory_reset
    self.restart_module(BAUD_LOOKUP[PARAM_DEFAULT_BAUD])
  File "/home/auke/Downloads/LD2410/LD2410/ld2410.py", line 208, in restart_module
    self.ser = self.ser = serial.Serial(self.port, BAUD_LOOKUP[self.baudrate], timeout=self.timeout)
KeyError: 256000
```